### PR TITLE
use js.utils 0.2.0, because 0.2.01 won't install

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "sudo": "~1.0.3",
     "date-format-lite": "~0.5.0",
-    "js.utils": "~0.2.0",
+    "js.utils": "0.2.0",
     "underscore": "~1.7.0"
   },
   "devDependencies": {},


### PR DESCRIPTION
for #6 
